### PR TITLE
Install ruby-full over ruby package for Alpine development environment

### DIFF
--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,4 +1,4 @@
 ---
 ruby_pkgs:
-  - ruby
+  - ruby-full
   - ruby-dev


### PR DESCRIPTION
Install ruby with all bundled gems in Alpine to ensure external gem installs are functional

Alpine Package References: 
* [ruby-full](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ruby-full)
* [ruby](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ruby)